### PR TITLE
Show login prompts as blocking modals

### DIFF
--- a/event_marketing_app.py
+++ b/event_marketing_app.py
@@ -302,6 +302,91 @@ metrics = st.sidebar.multiselect(
     default=["Social Mentions", "Video Views (VOD)", "Hours Watched (Streams)"],
 )
 
+# Reset login decisions if metrics change
+if "Social Mentions" not in metrics:
+    for k in [
+        "onclusive_decision",
+        "manual_social_toggle",
+        "onclusive_user",
+        "onclusive_pw",
+        "onclusive_query",
+    ]:
+        st.session_state.pop(k, None)
+
+if not any(m in ["Video Views (VOD)", "Hours Watched (Streams)"] for m in metrics):
+    for k in ["levelup_decision", "manual_levelup_toggle", "levelup_jwt"]:
+        st.session_state.pop(k, None)
+
+# ─ Pop‑up guidance when certain metrics are selected ───────────────────────
+if "Social Mentions" in metrics:
+    if not st.session_state.get("onclusive_msg_shown"):
+        st.toast(
+            "Social Mentions selected → scroll down to log in to Onclusive or choose manual input.",
+            icon="🔔",
+        )
+        st.session_state["onclusive_msg_shown"] = True
+else:
+    st.session_state["onclusive_msg_shown"] = False
+
+if any(m in ["Video Views (VOD)", "Hours Watched (Streams)"] for m in metrics):
+    if not st.session_state.get("levelup_msg_shown"):
+        st.toast(
+            "Video metric selected → scroll down to sign in with LevelUp or use manual entry.",
+            icon="🔔",
+        )
+        st.session_state["levelup_msg_shown"] = True
+else:
+    st.session_state["levelup_msg_shown"] = False
+
+# ─ Blocking login modals ────────────────────────────────────────────────────
+if "Social Mentions" in metrics and not st.session_state.get("onclusive_decision"):
+    with st.modal("Onclusive Login Required", key="onclusive_block"):
+        st.markdown(
+            "<div style='border:2px solid #999; background:#f8f8f8; padding:20px; text-align:center;'>",
+            unsafe_allow_html=True,
+        )
+        st.write("Please log in to Onclusive or skip to manual entry.")
+        o_user = st.text_input("Onclusive Username", key="modal_onclusive_user")
+        o_pw = st.text_input("Onclusive Password", type="password", key="modal_onclusive_pw")
+        o_query = st.text_input("Search Keywords", key="modal_onclusive_query")
+        col1, col2 = st.columns(2)
+        if col1.button("Log In", key="onclusive_login_btn"):
+            st.session_state["onclusive_user"] = o_user
+            st.session_state["onclusive_pw"] = o_pw
+            st.session_state["onclusive_query"] = o_query
+            st.session_state["manual_social_toggle"] = False
+            st.session_state["onclusive_decision"] = True
+            st.experimental_rerun()
+        if col2.button("Skip (Manual)", key="onclusive_skip_btn"):
+            st.session_state["manual_social_toggle"] = True
+            st.session_state["onclusive_decision"] = True
+            st.experimental_rerun()
+        st.markdown("</div>", unsafe_allow_html=True)
+
+if (
+    any(m in ["Video Views (VOD)", "Hours Watched (Streams)"] for m in metrics)
+    and not st.session_state.get("levelup_decision")
+):
+    with st.modal("LevelUp Login Required", key="levelup_block"):
+        st.markdown(
+            "<div style='border:2px solid #999; background:#f8f8f8; padding:20px; text-align:center;'>",
+            unsafe_allow_html=True,
+        )
+        st.write("Video metrics selected. Sign in with LevelUp or skip to manual entry.")
+        col1, col2 = st.columns(2)
+        if col1.button("Login with Google", key="levelup_login_btn"):
+            jwt = get_levelup_jwt()
+            if jwt:
+                st.session_state["levelup_jwt"] = jwt
+                st.session_state["manual_levelup_toggle"] = False
+                st.session_state["levelup_decision"] = True
+                st.experimental_rerun()
+        if col2.button("Skip (Manual)", key="levelup_skip_btn"):
+            st.session_state["manual_levelup_toggle"] = True
+            st.session_state["levelup_decision"] = True
+            st.experimental_rerun()
+        st.markdown("</div>", unsafe_allow_html=True)
+
 regions = st.sidebar.multiselect(
     "Output Regions (sheet tabs):",
     ["US", "GB", "AU", "CA", "FR", "DE", "JP", "KR"],
@@ -311,17 +396,18 @@ regions = st.sidebar.multiselect(
 # ─ Main: Conditional Login or Manual Inputs Based on Metrics ─────────────────
 
 # 1) Initialize variables for Onclusive (Digimind)
-onclusive_username = None
-onclusive_password = None
-onclusive_language = "en"
-onclusive_query = None
+onclusive_username = st.session_state.get("onclusive_user")
+onclusive_password = st.session_state.get("onclusive_pw")
+onclusive_language = st.session_state.get("onclusive_lang", "en")
+onclusive_query = st.session_state.get("onclusive_query")
 manual_social_inputs: dict[int, tuple[int, int]] = {}
 
 if "Social Mentions" in metrics:
     st.subheader("🔐 Onclusive (Digimind) for Social Mentions")
     use_manual_social = st.checkbox(
         "❔ Enter Social Mentions counts manually (skip Onclusive)",
-        key="manual_social_toggle"
+        key="manual_social_toggle",
+        value=st.session_state.get("manual_social_toggle", False),
     )
     if use_manual_social:
         st.info("Provide baseline & actual Social Mentions per event.")
@@ -359,14 +445,15 @@ if "Social Mentions" in metrics:
 
 
 # 2) Initialize variables for LevelUp (Google SSO)
-levelup_jwt = None
+levelup_jwt = st.session_state.get("levelup_jwt")
 manual_levelup_inputs: dict[int, dict[str, tuple[int, int]]] = {}
 
 if any(m in ["Video Views (VOD)", "Hours Watched (Streams)"] for m in metrics):
     st.subheader("🎮 LevelUp (Google SSO) for Video Views & Hours Watched")
     use_manual_levelup = st.checkbox(
         "❔ Enter LevelUp metrics manually (skip Google SSO)",
-        key="manual_levelup_toggle"
+        key="manual_levelup_toggle",
+        value=st.session_state.get("manual_levelup_toggle", False),
     )
     if use_manual_levelup:
         st.info("Provide baseline & actual values for LevelUp metrics per event.")
@@ -412,10 +499,10 @@ if st.button("Generate Template"):
 
     # 2) Acquire LevelUp JWT via Device-Code Flow if needed
     if any(m in ["Video Views (VOD)", "Hours Watched (Streams)"] for m in metrics) and not manual_levelup_inputs:
-        # Attempt SSO login if not manual
-        levelup_jwt = get_levelup_jwt()
         if not levelup_jwt:
-            st.stop()
+            levelup_jwt = get_levelup_jwt()
+            if not levelup_jwt:
+                st.stop()
 
     # 3) Build Excel sheets
     with st.spinner("Building Excel…"):

--- a/event_marketing_app.py
+++ b/event_marketing_app.py
@@ -299,7 +299,7 @@ metrics = st.sidebar.multiselect(
         "Sessions", "DAU", "Revenue", "Installs", "Retention", "Watch Time", "ARPU", "Conversions",
         "Video Views (VOD)", "Hours Watched (Streams)", "Social Mentions", "Search Index", "PCCV", "AMA"
     ],
-    default=["Social Mentions", "Video Views (VOD)", "Hours Watched (Streams)"],
+    default=[],
 )
 
 # Reset login decisions if metrics change
@@ -390,7 +390,7 @@ if (
 regions = st.sidebar.multiselect(
     "Output Regions (sheet tabs):",
     ["US", "GB", "AU", "CA", "FR", "DE", "JP", "KR"],
-    default=["US", "GB"],
+    default=[],
 )
 
 # ─ Main: Conditional Login or Manual Inputs Based on Metrics ─────────────────


### PR DESCRIPTION
## Summary
- reset login state when metrics change
- require Onclusive or LevelUp login using modal dialogs before app interaction
- remember login choices with session state

## Testing
- `python -m py_compile event_marketing_app.py`


------
https://chatgpt.com/codex/tasks/task_e_6840ff3b9cf883229eedf957f3d90697